### PR TITLE
fix: fix some known bugs

### DIFF
--- a/controllers/tunnel.go
+++ b/controllers/tunnel.go
@@ -95,12 +95,12 @@ func (c *ApiController) GetAssetTunnel() {
 
 	intWidth, err := strconv.Atoi(width)
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 	intHeight, err := strconv.Atoi(height)
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 
@@ -109,19 +109,19 @@ func (c *ApiController) GetAssetTunnel() {
 	remoteAppArgs := c.Input().Get("remoteAppArgs")
 
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 
 	session, err := object.GetConnSession(sessionId)
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 
 	asset, err := object.GetAsset(session.AssetId)
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (c *ApiController) GetAssetTunnel() {
 
 	_, err = object.UpdateSession(sessionId, session)
 	if err != nil {
-		c.ResponseError(err.Error())
+		panic(err)
 		return
 	}
 
@@ -189,14 +189,12 @@ func (c *ApiController) GetAssetTunnel() {
 		if err != nil {
 			_ = tunnel.Close()
 			object.CloseSession(sessionId, Normal, "Normal user exit")
-			c.ResponseOk()
 			return
 		}
 
 		_, err = tunnel.WriteAndFlush(message)
 		if err != nil {
 			object.CloseSession(sessionId, Normal, "Normal user exit")
-			c.ResponseOk()
 			return
 		}
 	}

--- a/controllers/tunnel.go
+++ b/controllers/tunnel.go
@@ -113,20 +113,20 @@ func (c *ApiController) GetAssetTunnel() {
 		return
 	}
 
-	s, err := object.GetConnSession(sessionId)
+	session, err := object.GetConnSession(sessionId)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
-	asset, err := object.GetAsset(s.AssetId)
+	asset, err := object.GetAsset(session.AssetId)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
 	configuration := guacamole.NewConfiguration()
-	configuration.Protocol = s.Protocol
+	configuration.Protocol = session.Protocol
 	propertyMap := configuration.LoadConfig()
 
 	setConfig(propertyMap, configuration)
@@ -135,12 +135,12 @@ func (c *ApiController) GetAssetTunnel() {
 	configuration.SetParameter("height", height)
 	configuration.SetParameter("dpi", dpi)
 
-	configuration.SetParameter("hostname", s.IP)
-	configuration.SetParameter("port", strconv.Itoa(s.Port))
-	configuration.SetParameter("username", s.Username)
-	configuration.SetParameter("password", s.Password)
+	configuration.SetParameter("hostname", session.IP)
+	configuration.SetParameter("port", strconv.Itoa(session.Port))
+	configuration.SetParameter("username", session.Username)
+	configuration.SetParameter("password", session.Password)
 
-	if s.Protocol == "rdp" && asset.EnableRemoteApp {
+	if session.Protocol == "rdp" && asset.EnableRemoteApp {
 		configuration.SetParameter("remote-app", "||"+remoteAppName)
 		configuration.SetParameter("remote-app-dir", remoteAppDir)
 		configuration.SetParameter("remote-app-args", remoteAppArgs)
@@ -162,19 +162,19 @@ func (c *ApiController) GetAssetTunnel() {
 
 	guacSession.Observer = guacamole.NewObserver(sessionId)
 	guacamole.GlobalSessionManager.Add(guacSession)
-	session := object.Session{
-		ConnectionId: tunnel.ConnectionID,
-		Width:        intWidth,
-		Height:       intHeight,
-		Status:       object.Connecting,
-		Recording:    configuration.GetParameter(guacamole.RecordingPath),
-	}
+
+	session.ConnectionId = tunnel.ConnectionID
+	session.Width = intWidth
+	session.Height = intHeight
+	session.Status = object.Connecting
+	session.Recording = configuration.GetParameter(guacamole.RecordingPath)
+
 	if session.Recording == "" {
 		// No audit is required when no screen is recorded
 		session.Reviewed = true
 	}
 
-	_, err = object.UpdateSession(sessionId, &session, []string{"status", "connectionId", "width", "height", "recording", "review"}...)
+	_, err = object.UpdateSession(sessionId, session)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
@@ -189,12 +189,14 @@ func (c *ApiController) GetAssetTunnel() {
 		if err != nil {
 			_ = tunnel.Close()
 			object.CloseSession(sessionId, Normal, "Normal user exit")
+			c.ResponseOk()
 			return
 		}
 
 		_, err = tunnel.WriteAndFlush(message)
 		if err != nil {
 			object.CloseSession(sessionId, Normal, "Normal user exit")
+			c.ResponseOk()
 			return
 		}
 	}

--- a/controllers/tunnel.go
+++ b/controllers/tunnel.go
@@ -81,6 +81,8 @@ func (c *ApiController) AddAssetTunnel() {
 }
 
 func (c *ApiController) GetAssetTunnel() {
+	// https://blog.csdn.net/weixin_51507240/article/details/131761587
+	c.EnableRender = false
 	ctx := c.Ctx
 	ws, err := UpGrader.Upgrade(ctx.ResponseWriter, ctx.Request, nil)
 	if err != nil {

--- a/controllers/tunnel.go
+++ b/controllers/tunnel.go
@@ -188,22 +188,13 @@ func (c *ApiController) GetAssetTunnel() {
 		_, message, err := ws.ReadMessage()
 		if err != nil {
 			_ = tunnel.Close()
-
-			err := object.CloseSession(sessionId, Normal, "Normal user exit")
-			if err != nil {
-				c.ResponseError(err.Error())
-				return
-			}
+			object.CloseSession(sessionId, Normal, "Normal user exit")
 			return
 		}
 
 		_, err = tunnel.WriteAndFlush(message)
 		if err != nil {
-			err := object.CloseSession(sessionId, Normal, "Normal user exit")
-			if err != nil {
-				c.ResponseError(err.Error())
-				return
-			}
+			object.CloseSession(sessionId, Normal, "Normal user exit")
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/casbin/casvisor/authz"
 	"github.com/casbin/casvisor/object"
 	"github.com/casbin/casvisor/routers"
+	"github.com/casbin/casvisor/task"
 )
 
 func main() {
@@ -50,6 +51,8 @@ func main() {
 		beego.BConfig.WebConfig.Session.SessionProviderConfig = beego.AppConfig.String("redisEndpoint")
 	}
 	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = 3600 * 24 * 365
+
+	task.NewTicker().SetupTicker()
 
 	beego.Run()
 }

--- a/object/session.go
+++ b/object/session.go
@@ -72,6 +72,10 @@ type Session struct {
 	CommandCount int64 `json:"commandCount"`
 }
 
+func (s *Session) GetId() string {
+	return util.GetIdFromOwnerAndName(s.Owner, s.Name)
+}
+
 func GetSessionCount(owner, status, field, value string) (int64, error) {
 	session := GetSession(owner, -1, -1, field, value, "", "")
 	return session.Count(&Session{Status: status})
@@ -95,6 +99,15 @@ func GetPaginationSessions(owner, status string, offset, limit int, field, value
 		return sessions, err
 	}
 
+	return sessions, nil
+}
+
+func GetSessionsByStatus(statuses []string) ([]*Session, error) {
+	sessions := []*Session{}
+	err := adapter.engine.In("status", statuses).Find(&sessions)
+	if err != nil {
+		return sessions, err
+	}
 	return sessions, nil
 }
 
@@ -151,6 +164,11 @@ func DeleteSession(session *Session) (bool, error) {
 	}
 
 	return affected != 0, nil
+}
+
+func DeleteSessionById(id string) (bool, error) {
+	owner, name := util.GetOwnerAndNameFromId(id)
+	return DeleteSession(&Session{Owner: owner, Name: name})
 }
 
 func AddSession(session *Session) (bool, error) {

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -69,6 +69,11 @@ func getObject(ctx *context.Context) (string, string) {
 	} else {
 		body := ctx.Input.RequestBody
 		if len(body) == 0 {
+			id := ctx.Request.Form.Get("id")
+			if id != "" {
+				return util.GetOwnerAndNameFromIdNoCheck(id)
+			}
+
 			return ctx.Request.Form.Get("owner"), ctx.Request.Form.Get("name")
 		}
 

--- a/task/ticker.go
+++ b/task/ticker.go
@@ -1,0 +1,47 @@
+package task
+
+import (
+	"github.com/casbin/casvisor/object"
+	"time"
+)
+
+type Ticker struct {
+}
+
+func NewTicker() *Ticker {
+	return &Ticker{}
+}
+
+func (t *Ticker) SetupTicker() {
+	// delete unused session every hour
+	unUsedSessionTicker := time.NewTicker(time.Hour)
+	go func() {
+		for range unUsedSessionTicker.C {
+			t.deleteUnUsedSession()
+		}
+	}()
+}
+
+func (t *Ticker) deleteUnUsedSession() {
+	sessions, err := object.GetSessionsByStatus([]string{object.NoConnect, object.Connecting})
+	if err != nil {
+		return
+	}
+
+	if len(sessions) > 0 {
+		now := time.Now()
+		for i := range sessions {
+			if sessions[i].ConnectedTime != "" {
+				connectedTime, err := time.ParseInLocation(time.RFC3339, sessions[i].ConnectedTime, time.Local)
+				if err != nil {
+					continue
+				}
+				if now.Sub(connectedTime).Hours() > 1 {
+					object.DeleteSessionById(sessions[i].GetId())
+				}
+			} else {
+				object.DeleteSessionById(sessions[i].GetId())
+			}
+		}
+	}
+}

--- a/task/ticker.go
+++ b/task/ticker.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package task
 
 import (

--- a/util/guacamole/tunnel.go
+++ b/util/guacamole/tunnel.go
@@ -198,25 +198,8 @@ func (t *Tunnel) Read() (p []byte, err error) {
 }
 
 func (t *Tunnel) Close() error {
-	if !t.IsOpen {
-		return nil
-	}
-
-	instruction := NewInstruction("disconnect")
-	if err := t.WriteInstructionAndFlush(instruction); err != nil {
-		return err
-	}
-
-	_, err := t.expect("ok")
-	if err != nil {
-		return err
-	}
-
-	err = t.conn.Close()
-	if err == nil {
-		t.IsOpen = false
-	}
-	return err
+	t.IsOpen = false
+	return t.conn.Close()
 }
 
 func Disconnect(ws *websocket.Conn, code int, msg string) {

--- a/web/src/SessionListPage.js
+++ b/web/src/SessionListPage.js
@@ -70,7 +70,10 @@ class SessionListPage extends BaseListPage {
           Setting.showMessage("success", i18next.t("general:Successfully stopped"));
           this.setState({
             data: Setting.deleteRow(this.state.data, i),
-            pagination: {total: this.state.pagination.total - 1},
+            pagination: {
+              ...this.state.pagination,
+              total: this.state.pagination.total - 1,
+            },
           });
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to stop")}: ${res.msg}`);

--- a/web/src/backend/SessionBackend.js
+++ b/web/src/backend/SessionBackend.js
@@ -39,9 +39,14 @@ export function updateSession(owner, name, session) {
 }
 
 export function addAssetTunnel(assetId, mode = "guacd") {
-  return fetch(`${Setting.ServerUrl}/api/add-asset-tunnel?assetId=${assetId}&mode=${mode}`, {
+  const formData = new FormData();
+  formData.append("assetId", assetId);
+  formData.append("mode", mode);
+
+  return fetch(`${Setting.ServerUrl}/api/add-asset-tunnel`, {
     method: "POST",
     credentials: "include",
+    body: formData,
   }).then(res => res.json());
 }
 
@@ -55,15 +60,23 @@ export function deleteSession(session) {
 }
 
 export function connect(sessionId) {
-  return fetch(`${Setting.ServerUrl}/api/start-session?id=${sessionId} `, {
+  const formData = new FormData();
+  formData.append("id", sessionId);
+
+  return fetch(`${Setting.ServerUrl}/api/start-session`, {
     method: "POST",
     credentials: "include",
+    body: formData,
   }).then(res => res.json());
 }
 
 export function disconnect(sessionId) {
-  return fetch(`${Setting.ServerUrl}/api/stop-session?id=${sessionId} `, {
+  const formData = new FormData();
+  formData.append("id", sessionId);
+
+  return fetch(`${Setting.ServerUrl}/api/stop-session`, {
     method: "POST",
     credentials: "include",
+    body: formData,
   }).then(res => res.json());
 }


### PR DESCRIPTION
1. Beego reports http injacks panic after closing websocket connection in function `GetAssetTunnel()`. Because after upgrade http to websocket, you can not use http.ResponseWriter to write messge.  
2. Set `c.EnableRender=flase` to  fix beego reports `Handler crashed with error can't find templatefile in the path`.
3. Using form pass params in POST request instead of url parmas.
4. Add ticker to clean unused sessions. 