### PR TITLE
feat: modernized docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,57 @@
-version: '3.1'
 services:
   casvisor:
     restart: always
-    build:
-      context: ./
-      dockerfile: Dockerfile
-      target: STANDARD
+    image: casbin/casvisor
     ports:
-      - "19000:19000"
-      - "3000:3000"
+      - "16001:16001"
     depends_on:
       - db
     environment:
       RUNNING_IN_DOCKER: "true"
     volumes:
       - ./conf:/home/casvisor/conf
+    deploy:
+      update_config:
+        order: start-first
+        failure_action: rollback
+        delay: 30s # Ensures casvisor starts 30 seconds after db
+        parallelism: 1
+    networks:
+      - default
+
   db:
     restart: always
     image: mysql:8.0.25
-    platform: linux/amd64
-    ports:
-      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: 123456
     volumes:
       - /usr/local/docker/mysql:/var/lib/mysql
+    deploy:
+      update_config:
+        order: stop-first
+        failure_action: rollback
+        delay: 0s
+        parallelism: 1
+    networks:
+      - default
+
   guacd:
     image: guacamole/guacd:latest
     environment:
       GUACD_LOG_LEVEL: debug
     volumes:
       - ./data/guacd:/usr/local/casvisor/data
-    ports:
-      - "4822:4822"
-    restart:
-      always
+    restart: always
+    depends_on:
+      - db
+    deploy:
+      update_config:
+        order: start-first
+        failure_action: rollback
+        delay: 0s
+        parallelism: 1
+    networks:
+      - default
+
+networks:
+  default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     restart: always
     image: casbin/casvisor
     ports:
-      - "16001:16001"
+      - "19000:19000"
     depends_on:
       - db
     environment:
@@ -14,7 +14,7 @@ services:
       update_config:
         order: start-first
         failure_action: rollback
-        delay: 30s # Ensures casvisor starts 30 seconds after db
+        delay: 15s
         parallelism: 1
     networks:
       - default


### PR DESCRIPTION
# Proposed Changes
- Modernized to the latest specs of Compose.
- set casvisor service to only expose the frontend port and not the backend port on all of the host interfaces.
- removed the unmentioned in the documentation port 3000 on the Casvisor port
- Modernized the restart and deploy strategy to optimize for uptime.
- Switched Casvisor service to the official image produced by Casvisor and pushed to the docker hub registry.
- Unpublished MySQL from all interfaces and is now exposed only internally to this docker-compose stack.
- Created an explicitly defined network that is technically superfluous.
- Staggered deployment so that Casvisor does not immediately start but the 30-second delay is technically arbitrary and can't be predicted as to how long MySQL will take to launch.
- unpublished Guacd from the 0.0.0.0 interface.  Meaning it now must be accessed entirely with docker's internal DNS via the separate default network.  This network could optionally have encryption turned on for those with tin foil hats.
- added a rollback function so that if an update fails to launch the container will automatically fall back to the last known good.