### PR TITLE
feat: add "signin" type records to logs

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -54,6 +54,8 @@ func (c *ApiController) Signin() {
 
 	claims.AccessToken = token.AccessToken
 	c.SetSessionClaims(claims)
+	userId := claims.User.Owner + "/" + claims.User.Name
+	c.Ctx.Input.SetParam("recordUserId", userId)
 
 	c.ResponseOk(claims)
 }


### PR DESCRIPTION
Part of: https://github.com/casvisor/casvisor/issues/112

The record logs are missing "signin" type. The reason is that the param "recordUserId" was not assigned a value during the login process, which caused the webhook after login to fail to write logs properly.