### PR TITLE
docs: add authgent to AI Agent Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@
 ## AI Agent Auth
 
 - [Arcade](https://github.com/ArcadeAI/arcade-ai) - Tool-calling platform with user approvals and authenticated actions for AI agents.
+- [authgent](https://github.com/authgent/authgent) - Self-hosted, open-source OAuth 2.1 identity provider for AI agents with RFC 8693 token exchange, DPoP, and multi-hop delegation chains; also ships a CLI that grades MCP servers' OAuth conformance.
 - [authsome](https://github.com/agentrhq/authsome) - Local-first credential broker for AI agents with an encrypted local vault and HTTPS proxy injection; no hosted service required.
 - [Composio](https://github.com/ComposioHQ/composio) - Hosted integration platform with managed OAuth and tool calling for 1000+ apps.
 - [Nango](https://github.com/NangoHQ/nango) - Open-source OAuth and API key handling for 700+ APIs with token refresh and a unified API for agent workloads.


### PR DESCRIPTION
Adds [authgent](https://github.com/authgent/authgent) to the **AI Agent Auth** section.

authgent is a self-hosted, Apache-2.0 OAuth 2.1 identity provider built specifically for AI agents. It sits naturally alongside the existing entries (Nango, authsome, Arcade):

- OAuth 2.1 with PKCE, client credentials, and RFC 8693 token exchange
- Multi-hop delegation chains (nested `act` claims) with scope reduction and depth limits
- DPoP sender-constrained tokens (RFC 9449), signed delegation receipts, human-in-the-loop step-up
- Bridges existing IdPs (Auth0/Okta/Clerk) via id_token exchange
- Also ships a CLI that grades MCP servers' OAuth conformance

Placed alphabetically between Arcade and authsome. Open-source (Apache-2.0), Python, published on PyPI.

Disclosure: I maintain authgent.